### PR TITLE
Add Redis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ This extension adds PHP support to Flatpak.
 
 PHP installs to `/usr/lib/sdk/php84` inside the sandbox.
 
-Example Visual Studio Code Configuration
+Example Visual Studio Code Configuration `settings.json`:
 
 ```json
-"php.validate.executablePath": "/usr/lib/sdk/php84/bin/php",
-"php.executablePath": "/usr/lib/sdk/php84/bin/php",
+{
+  "php.validate.executablePath": "/usr/lib/sdk/php84/bin/php",
+  "php.executablePath": "/usr/lib/sdk/php84/bin/php",
+}
 ```
 
 Includes
@@ -17,6 +19,7 @@ Includes
 * [composer](https://github.com/composer/composer)
 * [PHIVE](https://phar.io/)
 * [apcu](https://pecl.php.net/package/APCu)
+* [redis](https://pecl.php.net/package/redis)
 * [xdebug](https://xdebug.org/)
 
 Each Flatpak can have its own custom php configuration files.
@@ -25,12 +28,25 @@ e.g. for Visual Studio Code
 
 Global composer installs are limited to the Flatpak they were installed in.
 
-#### Troubleshooting
+## Troubleshooting
+
+### php: No such file or directory
+
 `/usr/bin/env: ‘php’: No such file or directory`
 
 Run `. /usr/lib/sdk/php84/enable.sh` or add `/usr/lib/sdk/php84/bin` to your $PATH.
 
-#### Modules
+### Usage with Laravel Extension
+
+To use the [Laravel extension](https://marketplace.visualstudio.com/items?itemName=laravel.vscode-laravel), update `settings.json` to use the sandbox php executable path:
+
+```json
+{
+    "Laravel.phpCommand": "/usr/lib/sdk/php84/bin/php",
+}
+```
+
+## Modules
 
 ```bash
 bash-5.0$ php -m
@@ -58,6 +74,7 @@ pdo_sqlite
 Phar
 posix
 random
+redis
 Reflection
 session
 SimpleXML
@@ -69,13 +86,16 @@ xdebug
 xml
 xmlreader
 xmlwriter
+Zend OPcache
 zip
 zlib
 
 [Zend Modules]
 Xdebug
+Zend OPcache
 ```
-#### Build
+
+## Build
 ```bash
 flatpak-builder --repo repo .build org.freedesktop.Sdk.Extension.php84.json --force-clean
 ```

--- a/files/php/opcache.ini
+++ b/files/php/opcache.ini
@@ -5,7 +5,7 @@ zend_extension=opcache
 opcache.enable=1
 
 ; Determines if Zend OPCache is enabled for the CLI version of PHP
-opcache.enable_cli=0
+opcache.enable_cli=1
 
 ; Enables or disables copying of PHP code (text segment) into HUGE PAGES.
 ; Under certain circumstances (if only a single global PHP process is

--- a/files/php/opcache.ini
+++ b/files/php/opcache.ini
@@ -5,7 +5,7 @@ zend_extension=opcache
 opcache.enable=1
 
 ; Determines if Zend OPCache is enabled for the CLI version of PHP
-opcache.enable_cli=1
+opcache.enable_cli=0
 
 ; Enables or disables copying of PHP code (text segment) into HUGE PAGES.
 ; Under certain circumstances (if only a single global PHP process is

--- a/files/redis/redis.ini
+++ b/files/redis/redis.ini
@@ -1,0 +1,2 @@
+; Enable Redis extension module
+extension = redis.so

--- a/org.freedesktop.Sdk.Extension.php84.json
+++ b/org.freedesktop.Sdk.Extension.php84.json
@@ -181,6 +181,46 @@
             ]
         },
         {
+            "name": "redis",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--with-php-config=/usr/lib/sdk/php84/bin/php-config"
+            ],
+            "post-install": [
+                "install -Dm755 modules/redis.so $(php -r 'echo ini_get(\"extension_dir\");')/redis.so",
+                "install -Dm644 redis.ini ${PHP_INI_DIR}/conf.d/05-xdebug.ini",
+                "install -Dm644 LICENSE ${FLATPAK_DEST}/share/licenses/xdebug/LICENSE"
+            ],
+            "cleanup": [
+                "/include",
+                "*.a",
+                "*.la"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/phpredis/phpredis/archive/6.1.0.tar.gz",
+                    "sha256": "57135db32a0ccb1659f56c75feb26c10ea94fb3d2471edd047d94a9800f959b0",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 18358,
+                        "stable-only": true,
+                        "url-template": "https://github.com/phpredis/phpredis/archive/$version.tar.gz"
+                    }
+                },
+                {
+                    "type": "file",
+                    "path": "files/redis/redis.ini"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "${FLATPAK_DEST}/bin/phpize"
+                    ]
+                }
+            ]
+        },
+        {
             "name": "composer",
             "buildsystem": "simple",
             "build-commands": [

--- a/org.freedesktop.Sdk.Extension.php84.json
+++ b/org.freedesktop.Sdk.Extension.php84.json
@@ -188,8 +188,8 @@
             ],
             "post-install": [
                 "install -Dm755 modules/redis.so $(php -r 'echo ini_get(\"extension_dir\");')/redis.so",
-                "install -Dm644 redis.ini ${PHP_INI_DIR}/conf.d/05-xdebug.ini",
-                "install -Dm644 LICENSE ${FLATPAK_DEST}/share/licenses/xdebug/LICENSE"
+                "install -Dm644 redis.ini ${PHP_INI_DIR}/conf.d/05-redis.ini",
+                "install -Dm644 LICENSE ${FLATPAK_DEST}/share/licenses/redis/LICENSE"
             ],
             "cleanup": [
                 "/include",


### PR DESCRIPTION
At the moment this Sdk causes my local Laravel projects to crash:
```
2024-12-23 16:57:25.124 [error] Parse Error:
 Paths

   Error 

  Class "Redis" not found

  at vendor/laravel/framework/src/Illuminate/Redis/Connectors/PhpRedisConnector.php:79
```
The problem is that the redis module is missing.

I would also recommend to enable the PDO extensions, e.g. ` pdo, sqlite, pdo_sqlite pdo_mysql pdo_postgres`